### PR TITLE
Set up deployment for api-worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ VERSION
 /api-worker/tsconfig.json
 
 *.toml
+!wrangler.toml
 /main-worker/wrangler.toml
 
 main-worker/wrangler.toml

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,112 @@
+# Deployment Guide
+
+## Frontend Deployment Setup
+
+This guide explains how to deploy the Vegvisr frontend application to Cloudflare Workers.
+
+### Prerequisites
+
+- Node.js (>= 20.11.1)
+- npm
+- Cloudflare account with Workers enabled
+- Wrangler CLI (included in dependencies)
+
+### Configuration
+
+The deployment is configured via `wrangler.toml` in the root directory:
+
+```toml
+name = "vegvisr-frontend"
+compatibility_date = "2025-01-13"
+
+[assets]
+directory = "./dist"
+
+# Optional: Environment-specific configuration
+[env.preview]
+name = "vegvisr-frontend-preview"
+
+[env.preview.assets]
+directory = "./dist"
+```
+
+### Deployment Commands
+
+#### Production Deployment
+```bash
+npm run deploy
+```
+
+#### Preview Deployment
+```bash
+npm run deploy:preview
+```
+
+#### Manual Deployment
+```bash
+# Build the application
+npm run build
+
+# Deploy to production
+npx wrangler deploy --env=
+
+# Deploy to preview
+npx wrangler deploy --env preview
+```
+
+### Troubleshooting
+
+#### Common Issues
+
+1. **Missing entry-point error**: Ensure `wrangler.toml` exists with correct assets configuration
+2. **Build failures**: Run `npm install` to ensure dependencies are installed
+3. **Authentication issues**: Run `npx wrangler login` to authenticate with Cloudflare
+
+#### Build Output
+
+The build process generates:
+- Static HTML, CSS, and JS files in `dist/` directory
+- Optimized assets with content hashing
+- Gzipped assets for faster loading
+
+#### File Structure After Build
+```
+dist/
+├── index.html
+├── assets/
+│   ├── *.js files
+│   ├── *.css files
+│   └── font files
+├── images/
+├── docs/
+└── other static files
+```
+
+### Environment Variables
+
+If your application requires environment variables, add them to your Cloudflare Workers environment:
+
+```bash
+npx wrangler secret put VARIABLE_NAME
+```
+
+### Performance Optimization
+
+The build includes several optimizations:
+- Code splitting for better load times
+- Asset compression
+- Tree shaking to remove unused code
+- Minification of all assets
+
+### Monitoring
+
+Monitor your deployment at:
+- Production: `https://vegvisr-frontend.your-domain.workers.dev`
+- Preview: `https://vegvisr-frontend-preview.your-domain.workers.dev`
+
+### Support
+
+For issues with:
+- Build process: Check Vite configuration in `vite.config.js`
+- Deployment: Check Wrangler configuration in `wrangler.toml`
+- Dependencies: Run `npm audit` to check for vulnerabilities

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "wrangler": "^4.20.5"
       },
       "engines": {
-        "node": "20.11.1"
+        "node": ">=20.11.1"
       }
     },
     "node_modules/@ai-sdk/provider": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "build": "vite build",
     "preview": "vite preview",
     "lint": "eslint . --fix",
-    "format": "prettier --write src/"
+    "format": "prettier --write src/",
+    "deploy": "npm run build && npx wrangler deploy --env=",
+    "deploy:preview": "npm run build && npx wrangler deploy --env preview"
   },
   "dependencies": {
     "@googlemaps/js-api-loader": "^1.16.8",
@@ -63,6 +65,6 @@
     "wrangler": "^4.20.5"
   },
   "engines": {
-    "node": "20.11.1"
+    "node": ">=20.11.1"
   }
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,12 @@
+name = "vegvisr-frontend"
+compatibility_date = "2025-01-13"
+
+[assets]
+directory = "./dist"
+
+# Optional: Environment-specific configuration
+[env.preview]
+name = "vegvisr-frontend-preview"
+
+[env.preview.assets]
+directory = "./dist"


### PR DESCRIPTION
Configure frontend deployment for Cloudflare Workers to resolve missing entry-point error.

The previous deployment command `npx wrangler deploy` failed because it lacked configuration for static asset deployment. This PR adds `wrangler.toml` to point to the `dist` directory, updates `package.json` with dedicated deploy scripts, and includes a `DEPLOYMENT.md` guide for future reference.