### PR TITLE
Clarify asset deployment configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "deploy:preview": "npm run build && npx wrangler deploy --env preview"
   },
   "dependencies": {
+    "@cloudflare/kv-asset-handler": "^0.3.4",
     "@googlemaps/js-api-loader": "^1.16.8",
     "ai": "^4.3.15",
     "axios": "^1.8.3",

--- a/src/worker.js
+++ b/src/worker.js
@@ -1,11 +1,15 @@
+import { getAssetFromKV } from '@cloudflare/kv-asset-handler'
+import manifestJSON from '__STATIC_CONTENT_MANIFEST'
+
+const assetManifest = JSON.parse(manifestJSON)
+
 export default {
   async fetch(request, env, ctx) {
     const url = new URL(request.url)
     const hostname = url.hostname
     console.log('Incoming request hostname:', hostname)
 
-    // Determine the target URL based on the path
-    let targetUrl
+    // Handle API proxy routes first
     if (
       url.pathname.startsWith('/getknowgraphs') ||
       url.pathname.startsWith('/getknowgraph') ||
@@ -14,31 +18,72 @@ export default {
       url.pathname.startsWith('/deleteknowgraph')
     ) {
       // Proxy API calls to the dev-worker
-      targetUrl =
+      const targetUrl =
         'https://knowledge-graph-worker.torarnehave.workers.dev' + url.pathname + url.search
-    } else {
-      // Proxy everything else to vegvisr.org
-      targetUrl = 'https://www.vegvisr.org' + url.pathname + url.search
+      
+      const headers = new Headers(request.headers)
+      headers.set('x-original-hostname', hostname)
+      
+      console.log('Headers being sent:', Object.fromEntries(headers.entries()))
+      console.log('Target URL:', targetUrl)
+      
+      const response = await fetch(targetUrl, {
+        method: request.method,
+        headers: headers,
+        body: request.body,
+        redirect: 'follow',
+      })
+      
+      return response
     }
 
-    // Create headers for the request
-    const headers = new Headers(request.headers)
-
-    // Set original hostname for KV-based filtering (no hardcoded filtering)
-    headers.set('x-original-hostname', hostname)
-
-    console.log('Headers being sent:', Object.fromEntries(headers.entries()))
-    console.log('Target URL:', targetUrl)
-
-    // Make the request
-    const response = await fetch(targetUrl, {
-      method: request.method,
-      headers: headers,
-      body: request.body,
-      redirect: 'follow',
-    })
-
-    // Return the response as-is (filtering handled by KV store)
-    return response
+    // Handle static file serving for the Vue.js SPA
+    try {
+      return await getAssetFromKV(
+        {
+          request,
+          waitUntil: ctx.waitUntil.bind(ctx),
+        },
+        {
+          ASSET_NAMESPACE: env.__STATIC_CONTENT,
+          ASSET_MANIFEST: assetManifest,
+          mapRequestToAsset: (request) => {
+            const url = new URL(request.url)
+            
+            // Handle root path
+            if (url.pathname === '/') {
+              return new Request(new URL('/index.html', request.url), request)
+            }
+            
+            // Handle static assets (with file extensions)
+            if (url.pathname.match(/\.[a-zA-Z0-9]+$/)) {
+              return request
+            }
+            
+            // Handle client-side routing - fallback to index.html
+            return new Request(new URL('/index.html', request.url), request)
+          },
+        }
+      )
+    } catch (e) {
+      console.error('Error serving asset:', e)
+      
+      // Fallback to index.html for any unmatched routes (SPA routing)
+      try {
+        return await getAssetFromKV(
+          {
+            request: new Request(new URL('/index.html', request.url), request),
+            waitUntil: ctx.waitUntil.bind(ctx),
+          },
+          {
+            ASSET_NAMESPACE: env.__STATIC_CONTENT,
+            ASSET_MANIFEST: assetManifest,
+          }
+        )
+      } catch (fallbackError) {
+        console.error('Fallback error:', fallbackError)
+        return new Response('Not Found', { status: 404 })
+      }
+    }
   },
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,12 +1,26 @@
 name = "vegvisr-frontend"
 compatibility_date = "2025-01-13"
+main = "src/worker.js"
 
-[assets]
-directory = "./dist"
+[build]
+command = "npm run build"
+
+[build.upload]
+format = "service-worker"
+
+[site]
+bucket = "./dist"
 
 # Optional: Environment-specific configuration
 [env.preview]
 name = "vegvisr-frontend-preview"
+main = "src/worker.js"
 
-[env.preview.assets]
-directory = "./dist"
+[env.preview.build]
+command = "npm run build"
+
+[env.preview.build.upload]
+format = "service-worker"
+
+[env.preview.site]
+bucket = "./dist"


### PR DESCRIPTION
Reconfigure Cloudflare Worker to correctly serve Vue.js SPA with client-side routing and API proxying, instead of a simple static asset worker.

The previous `wrangler.toml` configuration used `[assets]`, which caused Cloudflare to treat the deployment as a basic static asset server. This prevented the Vue.js application from handling client-side routes (e.g., `/admin/domains`) and properly proxying API calls, leading to "Failed to fetch" errors. This PR updates the `wrangler.toml` to use `[site]` and a `main` worker script, and modifies the worker to use `@cloudflare/kv-asset-handler` for correct SPA routing and static file serving, while maintaining existing API proxy logic.