### PR TITLE
Resume ongoing work

### DIFF
--- a/src/components/BrandingModal.vue
+++ b/src/components/BrandingModal.vue
@@ -1904,6 +1904,22 @@ export default {
     },
 
     openMenuTemplateCreator() {
+      // Check if a template is selected from the dropdown
+      if (this.formData.menuConfig.selectedTemplate) {
+        // Find the selected template in availableMenuTemplates
+        const selectedTemplate = this.availableMenuTemplates.find(
+          (t) => t.id === this.formData.menuConfig.selectedTemplate,
+        )
+        if (selectedTemplate) {
+          this.selectedMenuTemplate = selectedTemplate
+        } else {
+          this.selectedMenuTemplate = null
+        }
+      } else {
+        // No template selected, creating new template
+        this.selectedMenuTemplate = null
+      }
+      
       this.isMenuTemplateCreatorOpen = true
     },
 

--- a/src/components/BrandingModal.vue
+++ b/src/components/BrandingModal.vue
@@ -365,7 +365,8 @@
                         class="btn btn-outline-primary btn-sm me-2"
                         @click="openMenuTemplateCreator"
                       >
-                        <i class="fas fa-plus"></i> Create Template
+                        <i :class="formData.menuConfig.selectedTemplate ? 'fas fa-edit' : 'fas fa-plus'"></i> 
+                        {{ formData.menuConfig.selectedTemplate ? 'Edit Template' : 'Create Template' }}
                       </button>
                       <button
                         type="button"


### PR DESCRIPTION
Fix menu template editor to open selected template for editing and update button text dynamically.

The `openMenuTemplateCreator()` method in `BrandingModal.vue` was not correctly populating `selectedMenuTemplate`, causing the `MenuTemplateCreator` modal to always open blank instead of with the selected template for editing. This PR ensures the selected template is passed and updates the button text to "Edit Template" when a template is selected, improving UX.